### PR TITLE
DEEPSEEK-R1

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -580,6 +580,27 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 				// Generics potentially only match on the target class, not on the proxy...
 				RootBeanDefinition mbd = getMergedLocalBeanDefinition(beanName);
 				Class<?> targetType = mbd.getTargetType();
+
+				String scope = mbd.getScope();
+				if (targetType == null && scope != null && !scope.isEmpty()) {
+					String targetBeanName = "scopedTarget." + beanName;
+					if (containsBeanDefinition(targetBeanName)) {
+						RootBeanDefinition targetMbd = getMergedLocalBeanDefinition(targetBeanName);
+
+						ResolvableType targetResolvableType = targetMbd.targetType;
+						if (targetResolvableType == null) {
+							targetResolvableType = targetMbd.factoryMethodReturnType;
+							if (targetResolvableType == null) {
+								targetResolvableType = ResolvableType.forClass(targetMbd.getBeanClass());
+							}
+						}
+
+						if (typeToMatch.isAssignableFrom(targetResolvableType)) {
+							return true;
+						}
+					}
+				}
+
 				if (targetType != null && targetType != ClassUtils.getUserClass(beanInstance)) {
 					// Check raw class match as well, making sure it's exposed on the proxy.
 					Class<?> classToMatch = typeToMatch.resolve();

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java.rej
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java.rej
@@ -1,0 +1,9 @@
+diff a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java	(rejected hunks)
+@@ -29,6 +29,7 @@
+ import java.util.concurrent.ConcurrentHashMap;
+ import java.util.concurrent.CopyOnWriteArrayList;
+ import java.util.function.Predicate;
++import java.util.function.Supplier;
+ import java.util.function.UnaryOperator;
+ 
+ import org.springframework.beans.BeanUtils;

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/GenericTypeMatchingTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/GenericTypeMatchingTests.java
@@ -1,0 +1,46 @@
+package org.springframework.beans.factory.support;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AbstractBeanFactory#isTypeMatch} with scoped proxy beans that use generic types.
+ */
+class ScopedProxyGenericTypeMatchTests {
+
+	@Test
+	void scopedProxyBeanTypeMatching() {
+		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+
+		String proxyBeanName = "wordBean-" + UUID.randomUUID();
+		String targetBeanName = "scopedTarget." + proxyBeanName;
+
+		RootBeanDefinition targetDef = new RootBeanDefinition(SomeGenericSupplier.class);
+		targetDef.setScope("request");
+		factory.registerBeanDefinition(targetBeanName, targetDef);
+
+		RootBeanDefinition proxyDef = new RootBeanDefinition();
+		proxyDef.setScope("singleton");
+		proxyDef.setTargetType(ResolvableType.forClassWithGenerics(Supplier.class, String.class));
+		proxyDef.setAttribute("targetBeanName", targetBeanName);
+		factory.registerBeanDefinition(proxyBeanName, proxyDef);
+
+		ResolvableType supplierType = ResolvableType.forClassWithGenerics(Supplier.class, String.class);
+
+		assertThat(factory.isTypeMatch(proxyBeanName, supplierType)).isTrue();
+
+		assertThat(factory.getBeanNamesForType(supplierType)).contains(proxyBeanName);
+	}
+
+	static class SomeGenericSupplier implements Supplier<String> {
+		@Override
+		public String get() {
+			return "value";
+		}
+	}
+}


### PR DESCRIPTION
This PR enhances type matching for scoped proxy beans with generic types in `AbstractBeanFactory`. It adds logic to check the target bean's type when the proxy bean has a scope defined but no target type is directly available, ensuring correct type matching for generic scoped proxies.

**Changes:**

- **AbstractBeanFactory.java**: Added a new conditional block to handle scoped proxy beans by resolving the target bean's type through its `RootBeanDefinition` when the proxy has a scope but no target type. This includes checking the target bean's resolvable type (via `targetType`, `factoryMethodReturnType`, or bean class) and comparing it with the expected type for matching.

- **GenericTypeMatchingTests.java**: Introduced a new test class `ScopedProxyGenericTypeMatchTests` with a test method `scopedProxyBeanTypeMatching()` that verifies type matching for scoped proxy beans using generics. It registers both target and proxy bean definitions and asserts that the proxy bean matches the expected generic type.